### PR TITLE
Tildeverse RFC 2 compliance: respond to !rollcall as well as !botlist

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -47,7 +47,7 @@ class Oven(pydle.Client):
 
 
 
-      if msg == '!botlist':
+      if msg == '!botlist' or msg == '!rollcall':
         await self.message(chan, 'helo im owen\'s nice bot')
       if msg[:len(self.prefix)] == self.prefix:
 


### PR DESCRIPTION
According to [RFC 2](https://rfc.tildeverse.org/rfcs/2):

> For conformance with previous standards on other tilde boxes, bots SHOULD also respond to !rollcall with at least the command list.